### PR TITLE
Fix dmg dependency for old chef versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "james.cuzella@lyraphase.com"
 license          "GPL-3.0+"
 description      "Recipes to Install & Configure my workstation"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.4.0"
+version          "3.4.1"
 chef_version     ">= 12.0" if respond_to?(:chef_version)
 
 source_url 'https://github.com/LyraPhase/lyraphase_workstation' if respond_to?(:source_url)

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ require 'chef/version_constraint'
 
 supports         'mac_os_x'
 depends          'homebrew'
-depends          'dmg' unless respond_to?(:chef_version) and Chef::const_defined?(:VERSION) and Chef::VersionConstraint.new(">= 10.14.0").include?(Chef::VERSION.to_s)
+depends          'dmg' unless respond_to?(:chef_version) and Chef::const_defined?(:VERSION) and Chef::VersionConstraint.new(">= 14.0").include?(Chef::VERSION.to_s)
 depends          'osx' # For osx_defaults LWRP
 depends          'sprout-base'  # For `libraries/directory#recursive_directories()` function
 depends          'plist', '~> 0.9' # For `plist_file` LWRP (used in lyraphase_workstation::airfoil recipe)


### PR DESCRIPTION
v3.4.1 (hotfix)
======

Updates
-------

- Note that with version 4.0 of this Cookbook, there will be some breaking changes.
  - `lyraphase_workstation::gpg21`: Recipe has been deprecated, as planned & announced in the README

Bug Fixes
---------

- `lyraphase_workstation`: Fix bug where `dmg_package` LWRP was undefined on older Chef Infra / Chef Client versions.
  - Fixed version check in `metadata.rb` to conditionally include the `dmg` cookbook for this LWRP on Chef < 14.0